### PR TITLE
Minor changes to Schema/biograkn-covid.gql to make it compatible with grakn v1.8

### DIFF
--- a/Schema/biograkn-covid.gql
+++ b/Schema/biograkn-covid.gql
@@ -110,28 +110,28 @@ bibliography-reference sub relation,
 
 # Attributes
 
-identifier sub attribute, datatype string; 
+identifier sub attribute, value string; 
 paper-id sub identifier;
-title sub attribute, datatype string; 
-section-name sub attribute, datatype string; 
-text sub attribute, datatype string; 
-start sub attribute, datatype long; 
-end sub attribute, datatype long; 
-name sub attribute, datatype string; 
+title sub attribute, value string; 
+section-name sub attribute, value string; 
+text sub attribute, value string; 
+start sub attribute, value long; 
+end sub attribute, value long; 
+name sub attribute, value string; 
 first-name sub name; 
 middle-name sub name; 
 last-name sub name; 
 country-name sub name;
-email sub attribute, datatype string; 
+email sub attribute, value string; 
 ref-id sub identifier;
-title sub attribute, datatype string; 
-year sub attribute, datatype long; 
-venue sub attribute, datatype string; 
-volume sub attribute, datatype long; 
-issn sub attribute, datatype string; 
-pages sub attribute, datatype string; 
-pmid sub attribute, datatype string; 
-language sub attribute, datatype string;
+title sub attribute, value string; 
+year sub attribute, value long; 
+venue sub attribute, value string; 
+volume sub attribute, value long; 
+issn sub attribute, value string; 
+pages sub attribute, value string; 
+pmid sub attribute, value string; 
+language sub attribute, value string;
 
 ### Rules: 
 ### 1: When text -> cite span -> bib reference -> paper then text -> paper 
@@ -201,29 +201,29 @@ extended-lens-family sub relation,
 	has family-id,
 	relates extended-familiar-patent;
 
-publication-number sub attribute, datatype string;
+publication-number sub attribute, value string;
 lens-id sub identifier;
 family-id sub identifier;
-publication-date sub attribute, datatype string;
-publication-year sub attribute, datatype string;
+publication-date sub attribute, value string;
+publication-year sub attribute, value string;
 application-number sub identifier;
-application-date sub attribute, datatype string;
-priority-numbers sub attribute, datatype long;
-earliest-priority-date sub attribute, datatype string;
-URL sub attribute, datatype string;
-patent-type sub attribute, datatype string;
-cited-by-patent-count sub attribute, datatype string;
-simple-family-size sub attribute, datatype string;
-extended-family-size sub attribute, datatype string;
-sequence-count sub attribute, datatype string;
-cpc-classifications sub attribute, datatype string;
-IPCR-classifications sub attribute, datatype string;
-US-classifications sub attribute, datatype string;
-NPL-citation-count sub attribute, datatype string;
-NPL-resolved-citation-count sub attribute, datatype string;
-NPL-resolved-lens-id sub attribute, datatype string;
-NPL-resolved-external-id sub attribute, datatype string;
-NPL-citations sub attribute, datatype string;
+application-date sub attribute, value string;
+priority-numbers sub attribute, value long;
+earliest-priority-date sub attribute, value string;
+URL sub attribute, value string;
+patent-type sub attribute, value string;
+cited-by-patent-count sub attribute, value string;
+simple-family-size sub attribute, value string;
+extended-family-size sub attribute, value string;
+sequence-count sub attribute, value string;
+cpc-classifications sub attribute, value string;
+IPCR-classifications sub attribute, value string;
+US-classifications sub attribute, value string;
+NPL-citation-count sub attribute, value string;
+NPL-resolved-citation-count sub attribute, value string;
+NPL-resolved-lens-id sub attribute, value string;
+NPL-resolved-external-id sub attribute, value string;
+NPL-citations sub attribute, value string;
 
 
 ######
@@ -436,7 +436,7 @@ disease-class-association sub relation,
 	organism-name sub name;
 	virus-name sub name; 
 
-identifier sub attribute, datatype string;
+identifier sub attribute, value string;
 	complex-id sub identifier;
 		complexportal-id sub complex-id;
 	gene-id sub identifier;
@@ -459,13 +459,13 @@ identifier sub attribute, datatype string;
 	drug-chembl-id sub identifier;
 	snpId sub identifier;
 
-identity-percentage sub attribute, datatype string;
-go-evidence-code sub attribute, datatype string; 
-go-taxon sub attribute, datatype long; 
-function-description sub attribute, datatype string;
-start-location sub attribute, datatype long;
-end-location sub attribute, datatype long;
-disgenet-score sub attribute, datatype double;
+identity-percentage sub attribute, value string;
+go-evidence-code sub attribute, value string; 
+go-taxon sub attribute, value long; 
+function-description sub attribute, value string;
+start-location sub attribute, value long;
+end-location sub attribute, value long;
+disgenet-score sub attribute, value double;
 
 ### Rules
 


### PR DESCRIPTION
Hi,
I have made a minor change of the word `datatype` to `value` in the biograkn-covid.gql file.  
The changes were successfully tested using grakn v1.8 server and grakn-workbase v1.3.1

