### PR TITLE
Update to the TypeDB 2.10.0 and client-python 2.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ Our team currently consists of a partnership between [GSK](http://gsk.com/), [Ox
 The schema that models the underlying knowledge graph alongside the descriptive query language, TypeQL, makes writing complex queries an extremely straightforward and intuitive process. Furthermore, TypeDB's automated reasoning, allows Bio Covid to become an intelligent database of biomedical data for the Covid research field that infers implicit knowledge based on the explicitly stored data. TypeDB Data - Bio Covid can understand biological facts, infer based on new findings and enforce research constraints, all at query (run) time.
 
 ## Installation
-**Prerequesites**: Python >3.6, [TypeDB Core 2.3.3](https://vaticle.com/download#core), [TypeDB Python Client API 2.2.0](https://docs.vaticle.com/docs/client-api/python), [Workbase 2.1.2](https://vaticle.com/download#workbase).
+**Prerequesites**: Python >3.6, [TypeDB Core 2.10.0](https://vaticle.com/download#core), [TypeDB Python Client API 2.9.0](https://docs.vaticle.com/docs/client-api/python), 
+
+**Note**: we have deprecated TypeDB Workbase, which produced the images above,
+and replaced it with the brand-new [TypeDB Studio ](https://github.com/vaticle/typedb-studio/releases) which has 
+the same features, plus much much more!
 
 Clone this repo:
 

--- a/migrator.py
+++ b/migrator.py
@@ -35,7 +35,7 @@ NUM_DR = 10000000  # Total drug to migrate (32k total)
 NUM_INT = 10000000  # Total drug-gene interactions to migrate (42k total)
 NUM_PATH = 10000000  # Total pathway associations to migrate
 NUM_TN = 10000000  # Total TissueNet being migrated
-NUM_PA = 10000000  #  Total Tissues <> Genes to migrate
+NUM_PA = 10000000  # Total Tissues <> Genes to migrate
 NUM_NER = 10000000  # Total number of publications (authors: 110k; journals: 1.7k; publications: 29k)
 NUM_SEM = 10000000  # Total number of rows from Semmed to migrate
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 certifi==2020.12.5
 chardet==4.0.0
-typedb-client==2.2.0
-typedb-protocol==2.2.0
+typedb-client==2.9.0
 idna==2.10
 numpy==1.20.1
 pandas==1.2.2


### PR DESCRIPTION
We upgrade the underlying TypeDB Client to 2.9.0, which enables loading TypeDB Bio into TypeDB 2.10.0.